### PR TITLE
fully qualified syntax for Self::Parameters

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -37,7 +37,7 @@ pub fn derive_arbitrary(input: DeriveInput) -> Result<TokenStream> {
         quote! {
             #type_parameters
             type Strategy = proptest::strategy::BoxedStrategy<Self>;
-            fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+            fn arbitrary_with(args: <Self as proptest::arbitrary::Arbitrary>::Parameters) -> Self::Strategy {
                 #[allow(dead_code)]
                 fn _to_fn_ptr<T>(f: fn(&T) -> bool) -> fn(&T) -> bool {
                     f

--- a/tests/arbitrary.rs
+++ b/tests/arbitrary.rs
@@ -1053,3 +1053,13 @@ fn manual_bound_variant() {
     }
     assert_arbitrary(any::<u16>().prop_map(|x| Outer::X(Inner(x))));
 }
+
+#[test]
+fn enum_with_variant_named_parameters() {
+    #[deny(warnings)]
+    #[derive(Arbitrary, Debug, PartialEq, Clone)]
+    enum MyEnum {
+        Parameters,
+        SomethingElse,
+    }
+}


### PR DESCRIPTION
In a codebase that I work on, we have an `enum` that has a variant called `Parameters`, which causes a warning. A minimal failing example looks like:
```rust
#[derive(Arbitrary)]
enum Enum {
  Parameters
}
```
Part of the expansion includes: `Self::Parameters`, which is ambiguous (either it's the associated type from `Arbitrary`, or an the enum variant).

This PR changes this to use the fully qualified syntax `<Self as proptest::arbitrary::Arbitrary>::Parameters`, and adds a regression test for this case