### PR TITLE
Fix clippy unused field warning in proptest `Args` structs

### DIFF
--- a/src/proptest_fn.rs
+++ b/src/proptest_fn.rs
@@ -52,6 +52,7 @@ pub fn build_proptest(attr: TokenStream, mut item_fn: ItemFn) -> Result<TokenStr
     let args_fields = args.iter().map(|arg| &arg.field);
     let config = to_proptest_config(config_args);
     let ts = quote! {
+        #[allow(dead_code)]
         #[derive(test_strategy::Arbitrary, Debug)]
         struct #args_type_ident {
             #(#args_fields,)*


### PR DESCRIPTION
The latest clippy was warning about unused fields in `#[proptest]` annotated test functions. This PR fixes the warning by allowing dead code in the `...Args` struct. I also initially tried placing the `allow` above the fields but this broke the tests so I moved it back up top.

Another potential solution might be to use an underscore for the fields, though they would have to be transformed in the function body as well to maintain good ergononmics—I don't know the crate well enough to say so went with the simplest solution, hopefully it's a step in the right direction.

Here's an example of the warning:
```
warning: field `input` is never read
   |
87 | #[proptest]
   | ----------- field in this struct
88 | fn some_test(#[filter(SomeInput::is_valid)] input: SomeInput) {
   |                                             ^^^^^
   |
   = note: `_SomeTestAdvanceArgs` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
   = note: `#[warn(dead_code)]` on by default
```