### PR TITLE
Append generated test macro so next test macros are aware of it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ proptest = "1.6.0"
 trybuild = "1.0.96"
 tokio = { version = "1.38.0", features = ["rt-multi-thread"] }
 anyhow = "1.0.97"
+googletest = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ rust-version = "1.70.0"
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0.68", features = ["visit", "full", "extra-traits"] }
-quote = "1.0.36"
-proc-macro2 = "1.0.86"
+syn = { version = "2.0.100", features = ["visit", "full", "extra-traits"] }
+quote = "1.0.40"
+proc-macro2 = "1.0.94"
 structmeta = "0.3.0"
 
 [dev-dependencies]
 proptest = "1.6.0"
-trybuild = "1.0.96"
-tokio = { version = "1.38.0", features = ["rt-multi-thread"] }
+trybuild = "1.0.104"
+tokio = { version = "1.44.1", features = ["rt-multi-thread"] }
 anyhow = "1.0.97"
 googletest = "0.14.0"

--- a/tests/proptest_fn.rs
+++ b/tests/proptest_fn.rs
@@ -6,6 +6,11 @@ use proptest::{prelude::ProptestConfig, prop_assert};
 use test_strategy::proptest;
 use tokio::task::yield_now;
 
+use googletest::expect_that;
+use googletest::gtest;
+use googletest::matchers::*;
+use googletest::verify_that;
+
 #[proptest]
 fn example(_x: u32, #[strategy(1..10u32)] y: u32, #[strategy(0..#y)] z: u32) {
     assert!(1 <= y);
@@ -290,4 +295,11 @@ async fn anyhow_result_bail_async(#[strategy(1..10u8)] x: u8) -> anyhow::Result<
     prop_assert_anyhow!(x < 10);
     yield_now().await;
     anyhow::bail!("error");
+}
+
+#[proptest]
+#[gtest]
+fn googletest_result(#[strategy(1..10u8)] x: u8) -> googletest::Result<()> {
+    expect_that!(x, ge(1));
+    verify_that!(x, lt(10))
 }


### PR DESCRIPTION
This is an attempt to improve capabilities among test macros to avoid duplicated test runs which is rare to be aware of.

The rationale is simple: procedure of attribute macro see only attributes following it. Macros next to processing macro will not see generated macro if it is generated in-place. So, instead of generating test macro in-place, appending generated test macro will let macros next to processing macro have chance to react, for example, not generate test macro if there is already one.

Without the fix, the new test will run twice.

See also tokio-rs/tokio#6497, d-e-s-o/test-log#46, frondeus/test-case#143, la10736/rstest#291, google/googletest-rust#561, kezhuw/stuck#53.